### PR TITLE
[!] Don't run on PR review

### DIFF
--- a/.github/workflows/ci-cabal.yaml
+++ b/.github/workflows/ci-cabal.yaml
@@ -5,7 +5,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize]
 
 permissions: {}
 

--- a/.github/workflows/ci-cabal.yaml
+++ b/.github/workflows/ci-cabal.yaml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: [master]
     types: [opened, synchronize, reopened, closed]
-  pull_request_review:
-    branches: [master]
-    types: [submitted]
 
 permissions: {}
 

--- a/.github/workflows/ci-cabal.yaml
+++ b/.github/workflows/ci-cabal.yaml
@@ -5,7 +5,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
 
 permissions: {}
 

--- a/.github/workflows/ci-cabal.yaml
+++ b/.github/workflows/ci-cabal.yaml
@@ -16,16 +16,3 @@ jobs:
     steps:
       - name: List everything
         run: tree -alps .
-      - name: PR merged event
-        run: echo "${{ github.event.pull_request.merged }}"
-      - name: PR review event
-        run: echo "${{ github.event.review.state }}"
-      - name: PR push event (.ref)
-        run: echo "${{ github.event.push.ref }}"
-      - name: PR push event
-        run: echo "${{ github.event.push }}"
-      - name: PR full event
-        run: |
-          cat << EOL
-          ${{ toJson(github.event) }}
-          EOL


### PR DESCRIPTION
Running on PR review means running again after actions have passed, thus duplicating CI effort.

We lose the ability to retrigger CI by reviewing PR. This was useful if CI was flake but we could get it back by either closing and reopening the PR or by adding a label / comment and triggering CI based on that. Neither of these is included here.

Unfortunately, there is no way to run additional CI after review but just before merging. If we need this we'll need to add it via the label trigger (in which case we need to ensure we don't open ourselves to TOCTOU issues by timing attacks -- since it takes some time for CI to provision the machines, the PR author might push new code to the branch. We could fake this via `workflow_dispacth` trigger, maybe?).

Signed-off-by: Mihai Maruseac <mihai.maruseac@gmail.com>