### PR TITLE
Revert "Try to cache the toolchain itself."

### DIFF
--- a/.github/workflows/ci-cabal.yaml
+++ b/.github/workflows/ci-cabal.yaml
@@ -25,9 +25,6 @@ jobs:
       - name: List everything (pre)
         run: tree -alps .
 
-      - name: List everything in toolchain (pre)
-        run: tree -alps /usr/local/.ghcup
-
       - name: List Haskell binaries (pre)
         run: |
           echo 'Cabal: '
@@ -43,13 +40,6 @@ jobs:
           echo 'Stack: '
           which stack || true
           stack --version || true
-
-      # Change this whenever the toolchain step below changes
-      - name: Cache
-        uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d # v3.2.2
-        with:
-          path: /usr/local/.ghcup # This is a 630MB cache, adding 2 more mins to create!!
-          key: toolchain-v0
 
       - name: Setup Haskell Compiler (cabal)
         uses: haskell/actions/setup@93635e8c4ac823f55cf3444537a63d3f2fd589de # v2.1.0
@@ -72,6 +62,3 @@ jobs:
           echo 'Stack: '
           which stack || true
           stack --version || true
-
-      - name: List everything in toolchain (post)
-        run: tree -alps /usr/local/.ghcup


### PR DESCRIPTION
Reverts mihaimaruseac/io-manager#22

Not much benefit of doing this. Costly as it creates a 630MB and takes ~2 more minutes to build it on cache miss.