### PR TITLE
Add static checks CI to run as presubmit.

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -1,0 +1,28 @@
+name: Static checks
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+    types: [opened, synchronize]
+
+permissions: {}
+
+jobs:
+  hlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
+        with:
+          persist-credentials: false
+
+      - name: Set up HLint
+        uses: haskell/actions/hlint-setup@93635e8c4ac823f55cf3444537a63d3f2fd589de # v2.1.0
+
+      - name: Run HLint
+        uses: haskell/actions/hlint-setup@93635e8c4ac823f55cf3444537a63d3f2fd589de # v2.1.0
+        with:
+          path: .
+          fail-on: warning


### PR DESCRIPTION
For now, this only runs hlint, but in the future we might expand it to run other checks (e.g., hindent, generate cabal from hpack, etc.)

Signed-off-by: Mihai Maruseac <mihai.maruseac@gmail.com>